### PR TITLE
Main script should point to dist version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "homepage": "https://github.com/gf3/moment-range",
   "bugs": "https://github.com/gf3/moment-range/issues",
-  "main": "./lib/moment-range",
+  "main": "./dist/moment-range",
   "directories": {
     "lib": "./lib"
   },


### PR DESCRIPTION
The main script in package.json should be pointing to the compiled dist version of moment range since the lib version contains javascript features that are not supported in all browsers (i.e. `const`).
